### PR TITLE
Fix card scroll logic

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -194,11 +194,11 @@ window.addEventListener('load', () => {
     const maxPage = Math.ceil(filtered.length / PER_PAGE)
     if (currentPage > maxPage) currentPage = 1
 
+    window.scrollTo({ top: 0, behavior: 'auto' })
     renderProducts(filtered)
     drawPagination(filtered.length)
     drawActiveTags()
     highlightCardTags()
-    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   /* === 7. Carousel helpers =========================================== */


### PR DESCRIPTION
## Summary
- scroll to top before rendering product cards
- reduce scroll animation to `auto`

## Testing
- `npx prettier --write docs/assets/js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_684eba93b2f88330beaddb492120b4fb